### PR TITLE
Snaxchain: rollup file updated.

### DIFF
--- a/mainnet/rollup.json
+++ b/mainnet/rollup.json
@@ -30,7 +30,6 @@
   "batch_inbox_address": "0xfec57bd3729a5f930d4ee8ac5992fdc8988426e4",
   "deposit_contract_address": "0x936d881b4760d5e9b6d55b774f65c509236b4743",
   "l1_system_config_address": "0x9c9b78f798f821c2f6398f603825fd175e2427f9",
-  "protocol_versions_address": "0x0000000000000000000000000000000000000000",
-  "da_challenge_contract_address": "0x0000000000000000000000000000000000000000"
+  "protocol_versions_address": "0x0000000000000000000000000000000000000000"
 }
 

--- a/testnet/rollup.json
+++ b/testnet/rollup.json
@@ -30,7 +30,6 @@
   "batch_inbox_address": "0x0ea93dcea9be9b8738c3013f0ae5e3150fa1afa3",
   "deposit_contract_address": "0xa14f58b9753862c83d980b6ae789ce82be151281",
   "l1_system_config_address": "0x0b43cc3e4282f2a8b92a5194dae844a4ec2185cb",
-  "protocol_versions_address": "0x0000000000000000000000000000000000000000",
-  "da_challenge_contract_address": "0x0000000000000000000000000000000000000000"
+  "protocol_versions_address": "0x0000000000000000000000000000000000000000"
 }
 


### PR DESCRIPTION
There is a known issue of the latest opstack version. They deprecated that field (da_challenge_contract_address), it's only required if you use alt-da.